### PR TITLE
#include "wrapper/wrapperHostLib.h" must be under #ifdef __VXWORKS__ …

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -34,10 +34,10 @@
 
 #ifdef __VXWORKS__
 #include "vxworks.h"
+#include "wrapper/wrapperHostLib.h"
 #else
 #include "fmacros.h"
 #endif
-#include "wrapper/wrapperHostLib.h"
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/select.h>


### PR DESCRIPTION
…as it is a vxworks specific include file.